### PR TITLE
renamed Transform to Transformer at multiple places, java doc corrections

### DIFF
--- a/src/main/java/com/aerospike/connect/inbound/InboundMessageTransformer.java
+++ b/src/main/java/com/aerospike/connect/inbound/InboundMessageTransformer.java
@@ -21,23 +21,24 @@ package com.aerospike.connect.inbound;
 import com.aerospike.connect.inbound.operation.AerospikeRecordOperation;
 
 /**
- * Generate [{@link AerospikeRecordOperation}] from the com.aerospike.connect.inbound
- * record coming from some external system.
+ * Generate an {@link AerospikeRecordOperation} from an incoming message.
  *
  * <ul>
  *   <li> If you annotate your implementation with
  *   <a href="https://docs.oracle.com/javaee/7/api/javax/inject/Singleton.html">@Singleton</a>,
  *   it has to be thread safe because the same instance can be used by multiple threads.
  *   </li>
- *   <li> If not annotated with Singleton, then a new instance of transform will be created for every incoming message.
+ *   <li> If not annotated with Singleton, then a new instance of transformer will be created for every incoming
+ *   message.
  *   </li>
  * </ul>
  *
  * @param <T> incoming message type
  */
-public interface InboundMessageTransform<T> {
+public interface InboundMessageTransformer<T> {
     /**
-     * Transforms generic input message/record into [{@link AerospikeRecordOperation}] to apply on the Aerospike database.
+     * Transforms generic input message/record into {@link AerospikeRecordOperation} to apply on the Aerospike
+     * database.
      *
      * @param input Inbound message from the external system.
      * @return the operation to apply.

--- a/src/main/java/com/aerospike/connect/inbound/model/InboundMessageTransformerConfig.java
+++ b/src/main/java/com/aerospike/connect/inbound/model/InboundMessageTransformerConfig.java
@@ -18,8 +18,9 @@
 
 package com.aerospike.connect.inbound.model;
 
-import com.aerospike.connect.inbound.InboundMessageTransform;
+import com.aerospike.connect.inbound.InboundMessageTransformer;
 import com.aerospike.connect.inbound.operation.AerospikeCompositeRecordOperation;
+import com.aerospike.connect.inbound.operation.AerospikeRecordOperation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -34,24 +35,23 @@ import java.util.Map;
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter
-public class InboundMessageTransformConfig {
+public class InboundMessageTransformerConfig {
     /**
-     * Class to be used for converting inbound messages to the [{@link
-     * com.aerospike.connect.inbound.operation.AerospikeRecordOperation}].
+     * Class to be used for converting inbound messages to the {@link AerospikeRecordOperation}.
      */
     @JsonProperty("class")
-    private final Class<? extends InboundMessageTransform<?>>
-            inboundMessageTransformClass;
+    private final Class<? extends InboundMessageTransformer<?>>
+            inboundMessageTransformerClass;
 
     /**
-     * Custom parameters to be used by the custom transform.
+     * Custom parameters to be used by the custom transformer.
      */
     @Nullable
     @JsonProperty("params")
     private final Map<String, Object> transformConfig;
 
     /**
-     * Whether to allow [{@link AerospikeCompositeRecordOperation}] or not.
+     * Whether to allow {@link AerospikeCompositeRecordOperation} or not.
      */
     @JsonProperty("unsafe-composite-record-operations")
     private final boolean unsafeCompositeRecordOperation;
@@ -59,8 +59,8 @@ public class InboundMessageTransformConfig {
     /**
      * Private constructor for Jackson.
      */
-    private InboundMessageTransformConfig() {
-        inboundMessageTransformClass = null;
+    private InboundMessageTransformerConfig() {
+        inboundMessageTransformerClass = null;
         transformConfig = null;
         unsafeCompositeRecordOperation = false;
     }

--- a/src/main/java/com/aerospike/connect/inbound/operation/AerospikeCompositeRecordOperation.java
+++ b/src/main/java/com/aerospike/connect/inbound/operation/AerospikeCompositeRecordOperation.java
@@ -24,11 +24,11 @@ import lombok.Getter;
 import java.util.List;
 
 /**
- * A class to perform multiple [{@link AerospikeSingleRecordOperation}]s.
+ * A class to perform multiple {@link AerospikeSingleRecordOperation}s.
  * <p>
  * Execution of operations is not guaranteed to be consistent. To perform multiple updates
- * to the same record, it is recommended to use [{@link AerospikeOperateOperation}] which accepts list of
- * [{@link com.aerospike.client.Operation}]s.
+ * to the same record, it is recommended to use {@link AerospikeOperateOperation} which accepts list of
+ * {@link com.aerospike.client.Operation}s.
  * </p>
  */
 @AllArgsConstructor
@@ -36,7 +36,7 @@ import java.util.List;
 public class AerospikeCompositeRecordOperation implements AerospikeRecordOperation {
 
     /**
-     * List of [{@link AerospikeSingleRecordOperation}]
+     * List of {@link AerospikeSingleRecordOperation}
      */
     private final List<AerospikeSingleRecordOperation> operations;
 

--- a/src/main/java/com/aerospike/connect/inbound/operation/AerospikeOperateOperation.java
+++ b/src/main/java/com/aerospike/connect/inbound/operation/AerospikeOperateOperation.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 /**
  * Represents an Aerospike single record transaction specified as a list of
- * [{@link Operation}]s.
+ * {@link Operation}s.
  */
 @AllArgsConstructor
 @EqualsAndHashCode


### PR DESCRIPTION
renamed InboundMessageTransform to InboundMessageTransformer, InboundMessageTransformConfig to InboundMessageTransformerConfig

removed extra [] from the JavaDoc links