### PR TITLE
[CONNECTOR-1172] -  Fix vulnerability - kafka-clients Incorrect Imple…

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,8 +2,4 @@ ignore:
   'snyk:lic:maven:org.gnu:gnu-crypto:GPL-3.0':
     - '*':
         reason: Library Exception allows non-free use of gnu-crypto
-        expires: 2024-11-07T11:38:28.614Z
-  SNYK-JAVA-ORGJSON-5488379:
-    - '*':
-        reason: https://github.com/snyk/gradle-plugin/pull/24
-        expires: 2023-12-31T11:38:28.614Z
+        expires: 2025-12-31T23:59:59.614Z

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>3.6.1</version>
+            <version>3.9.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fix: upgrade org.apache.kafka:connect-api from 3.6.1 to 3.9.0

See this package in Maven Repository:
https://mvnrepository.com/artifact/org.apache.kafka/connect-api/

See this project in Snyk:
https://app.snyk.io/org/aerospike-connectors-streaming/project/602498cb-b9f2-4d24-af08-a8c90e34a90d