### PR TITLE
[CONNECTOR-1431] Aerospike Streaming Connectors - Security vulnerabilities - Jackson-core

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,10 +3,5 @@ ignore:
     - '*':
         reason: Library Exception allows non-free use of gnu-crypto
         expires: 2026-12-31T23:59:59.614Z
-  'SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551':
-    - '*':
-        reason: Jackson 2.18.7 is under development and can't upgrade to 2.21.2 due to conflicts in inbound connectors
-        expires: 2026-04-30T11:38:28.614Z
-
 exclude:
   - ./examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,8 @@ allprojects {
 
     // Common dependency versions.
     extra["aerospikeClientVersion"] = "10.0.0"
-    extra["jacksonVersion"] = "2.18.6"
+    extra["jacksonVersion"] = "2.21.2"
+    extra["jacksonAnnotationVersion"] = "2.21"
 
     dependencies {
         // Lombok for its @Generated annotation that jacoco ignores
@@ -85,7 +86,7 @@ allprojects {
         "api"("com.aerospike:aerospike-client-jdk8:${project.extra["aerospikeClientVersion"]}")
 
         // Jackson annotation
-        "api"("com.fasterxml.jackson.core:jackson-annotations:${project.extra["jacksonVersion"]}")
+        "api"("com.fasterxml.jackson.core:jackson-annotations:${project.extra["jacksonAnnotationVersion"]}")
 
         // Test dependencies
         testImplementation("com.aerospike:aerospike-client-jdk8:${project.extra["aerospikeClientVersion"]}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ allprojects {
     group = "com.aerospike"
 
     // Common dependency versions.
-    extra["aerospikeClientVersion"] = "10.0.0"
+    extra["aerospikeClientVersion"] = "9.3.0"
     extra["jacksonVersion"] = "2.21.2"
     extra["jacksonAnnotationVersion"] = "2.21"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     api("com.github.breadmoirai:github-release:2.5.2")
     api("com.github.ben-manes:gradle-versions-plugin:+")
 
-    val jacksonVersion = "2.18.6"
+    val jacksonVersion = "2.21.2"
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 }


### PR DESCRIPTION
* Removed the ignore Jackson vulnerability entry
* Upgraded jackson library to 2.21.2 to fix vulnerability
* Aligned dependency versions used by the connectors