### PR TITLE
[CONNECTOR-1558] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Jul'26

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,11 @@ pipeline {
         CONNECT_SNAPSHOTS_REPO_PASSWORD = credentials('connect-snapshots-repo-password')
         CONNECT_SNAPSHOTS_REPO_URL = credentials('connect-snapshots-repo-url')
         SNYK_TOKENS = credentials('snyk-tokens')
+        OSSRH_USERNAME = credentials('ossrh-username')
+        OSSRH_PASSWORD = credentials('ossrh-password')
+        SIGNING_KEY_ID = credentials('signing-key-id')
+        SIGNING_PASSWORD = credentials('signing-password')
+        SIGNING_SECRET_KEY_BASE64 = credentials('signing-secret-key-base64')
     }
 
     options {
@@ -34,6 +39,13 @@ pipeline {
                         sh "mvn -B -Dstyle.color=never -f examples/jms -U clean install"
                         sh "mvn -B -Dstyle.color=never -f examples/kafka clean install"
                         sh "mvn -B -Dstyle.color=never -f examples/pulsar clean install"
+                    }
+                }
+
+                stage("Validate Maven Central credentials") {
+                    steps {
+                        echo "Validating OSSRH credentials.."
+                        sh "./gradlew --no-daemon verifyOssrhCredentials"
                     }
                 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ import com.aerospike.connect.configureDependencyUpdate
 import com.aerospike.connect.configureProperties
 import com.aerospike.connect.createGithubPublishTasks
 import com.aerospike.connect.setupJavaBuild
+import com.aerospike.connect.setupOssrhCredentialValidation
 import com.aerospike.connect.setupPublishingTasks
 import com.aerospike.connect.setupReleaseTasks
 import com.aerospike.connect.setupTests
@@ -100,6 +101,7 @@ allprojects {
     project.setupReleaseTasks()
     project.setupPublishingTasks()
     project.createGithubPublishTasks()
+    project.setupOssrhCredentialValidation()
     project.setupVulnerabilityScanning()
     project.setupTests()
     project.configureDependencyUpdate()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ allprojects {
 
     // Common dependency versions.
     extra["aerospikeClientVersion"] = "9.3.0"
-    extra["jacksonVersion"] = "2.21.4"
+    extra["jacksonVersion"] = "2.22.1"
     extra["jacksonAnnotationVersion"] = "2.21"
 
     dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     api("com.github.breadmoirai:github-release:2.5.2")
     api("com.github.ben-manes:gradle-versions-plugin:+")
 
-    val jacksonVersion = "2.21.4"
+    val jacksonVersion = "2.22.1"
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 }

--- a/buildSrc/release.sh
+++ b/buildSrc/release.sh
@@ -28,7 +28,10 @@ usage: bash release.sh --version 1.1.0 --release-notes-file release-notes.md
   -n  (Required)          Path of release notes files
   -h                      Print usage help
 
-Requires github credentials as environment variables GITHUB_USERNAME and GITHUB_TOKEN
+Requires environment variables:
+  GITHUB_USERNAME, GITHUB_TOKEN
+  OSSRH_USERNAME, OSSRH_PASSWORD
+  SIGNING_KEY_ID, SIGNING_PASSWORD, SIGNING_SECRET_KEY_BASE64
 EOF
 }
 
@@ -75,6 +78,11 @@ echo "--------------------------------------------------------------------------
 
 # Run vulnerability scan on the module
 ./gradlew --stacktrace --no-daemon ":snyk-test"
+
+# Fail fast if Maven Central credentials are invalid
+./gradlew --stacktrace --no-daemon verifyOssrhCredentials \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=$version
 
 # Run the release task
 ./gradlew --stacktrace --no-daemon release publishGithubRelease -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=$version -PreleaseNotesFile="$releaseNotesFile"

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/OssrhValidationExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/OssrhValidationExtensions.kt
@@ -24,8 +24,8 @@ import java.net.HttpURLConnection
 import java.net.URI
 import java.util.Base64
 
-private const val OSSRH_PROFILE_URL =
-    "https://ossrh-staging-api.central.sonatype.com/service/local/staging/profile"
+private const val OSSRH_CREDENTIALS_URL =
+    "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any"
 
 /**
  * Register OSSRH credential validation and wire it ahead of publish tasks so
@@ -65,9 +65,10 @@ private fun Project.verifyOssrhCredentials() {
             "OSSRH password not configured (ossrhPassword / OSSRH_PASSWORD)"
         )
 
-    val connection = URI(OSSRH_PROFILE_URL).toURL().openConnection()
+    val connection = URI(OSSRH_CREDENTIALS_URL).toURL().openConnection()
         as HttpURLConnection
     connection.requestMethod = "GET"
+    // Use the same Basic auth that maven-publish sends for release uploads.
     connection.setRequestProperty(
         "Authorization",
         "Basic " + Base64.getEncoder().encodeToString(
@@ -78,6 +79,7 @@ private fun Project.verifyOssrhCredentials() {
     val responseCode = connection.responseCode
     if (responseCode != HttpURLConnection.HTTP_OK) {
         val errorBody = connection.errorStream?.bufferedReader()?.readText()
+            ?: connection.inputStream?.bufferedReader()?.readText()
         throw GradleException(
             "OSSRH credential validation failed (HTTP $responseCode)" +
                 (errorBody?.let { ": $it" } ?: "")

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/OssrhValidationExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/OssrhValidationExtensions.kt
@@ -1,0 +1,87 @@
+/*
+ *
+ *  Copyright 2012-2025 Aerospike, Inc.
+ *
+ *  Portions may be licensed to Aerospike, Inc. under one or more contributor
+ *  license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package com.aerospike.connect
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.Base64
+
+private const val OSSRH_PROFILE_URL =
+    "https://ossrh-staging-api.central.sonatype.com/service/local/staging/profile"
+
+/**
+ * Register OSSRH credential validation and wire it ahead of publish tasks so
+ * auth failures fail CI snapshot builds and release before GitHub publish.
+ */
+fun Project.setupOssrhCredentialValidation() {
+    tasks.register("verifyOssrhCredentials") {
+        group = "verification"
+        description =
+            "Verify OSSRH credentials before Maven Central publish"
+
+        onlyIf {
+            findProperty("ossrhUsername") != null &&
+                findProperty("ossrhPassword") != null
+        }
+
+        doLast {
+            verifyOssrhCredentials()
+        }
+    }
+
+    tasks.named("publish").configure {
+        dependsOn("verifyOssrhCredentials")
+    }
+    tasks.named("publishGithubRelease").configure {
+        dependsOn("verifyOssrhCredentials")
+    }
+}
+
+private fun Project.verifyOssrhCredentials() {
+    val username = findProperty("ossrhUsername") as? String
+        ?: throw GradleException(
+            "OSSRH username not configured (ossrhUsername / OSSRH_USERNAME)"
+        )
+    val password = findProperty("ossrhPassword") as? String
+        ?: throw GradleException(
+            "OSSRH password not configured (ossrhPassword / OSSRH_PASSWORD)"
+        )
+
+    val connection = URI(OSSRH_PROFILE_URL).toURL().openConnection()
+        as HttpURLConnection
+    connection.requestMethod = "GET"
+    connection.setRequestProperty(
+        "Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(
+            "$username:$password".toByteArray(Charsets.UTF_8)
+        )
+    )
+
+    val responseCode = connection.responseCode
+    if (responseCode != HttpURLConnection.HTTP_OK) {
+        val errorBody = connection.errorStream?.bufferedReader()?.readText()
+        throw GradleException(
+            "OSSRH credential validation failed (HTTP $responseCode)" +
+                (errorBody?.let { ": $it" } ?: "")
+        )
+    }
+    logger.lifecycle("OSSRH credentials validated successfully")
+}

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/PropertiesExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/PropertiesExtensions.kt
@@ -2,6 +2,7 @@ package com.aerospike.connect
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.extra
+import java.util.Base64
 
 fun Project.configureProperties() {
     applyCredentialsFromEnvironment()
@@ -23,4 +24,17 @@ private fun Project.applyCredentialsFromEnvironment() {
     )
     setFromEnv("connectSnapshotsRepo", "CONNECT_SNAPSHOTS_REPO_URL")
     setFromEnv("snykTokens", "SNYK_TOKENS")
+    setFromEnv("ossrhUsername", "OSSRH_USERNAME")
+    setFromEnv("ossrhPassword", "OSSRH_PASSWORD")
+    setFromEnv("signing.keyId", "SIGNING_KEY_ID")
+    setFromEnv("signing.password", "SIGNING_PASSWORD")
+    setSigningKeyFromBase64Env("SIGNING_SECRET_KEY_BASE64")
+}
+
+private fun Project.setSigningKeyFromBase64Env(envVar: String) {
+    val encoded = System.getenv(envVar) ?: return
+    extra["signing.secretKey"] = String(
+        Base64.getDecoder().decode(encoded.replace("\\s".toRegex(), "")),
+        Charsets.UTF_8
+    )
 }

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/PublishingExtensions.kt
@@ -128,8 +128,15 @@ fun Project.setupPublishingTasks() {
     val signing = (project.extensions["signing"] as SigningExtension)
     val signingSecretKey = findProperty("signing.secretKey") as? String
     if (signingSecretKey != null) {
-        val signingKeyId: String by project
-        val signingPassword: String by project
+        val signingKeyId = findProperty("signing.keyId") as? String
+            ?: error(
+                "signing.keyId not configured (SIGNING_KEY_ID / signing.keyId)"
+            )
+        val signingPassword = findProperty("signing.password") as? String
+            ?: error(
+                "signing.password not configured " +
+                    "(SIGNING_PASSWORD / signing.password)"
+            )
         signing.useInMemoryPgpKeys(
             signingKeyId,
             signingSecretKey,

--- a/buildSrc/src/main/kotlin/com/aerospike/connect/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aerospike/connect/PublishingExtensions.kt
@@ -40,6 +40,8 @@ fun Project.setupPublishingTasks() {
         val connectSnapshotsRepo: String by project
         val connectSnapshotsRepoUser: String by project
         val connectSnapshotsRepoPassword: String by project
+        val ossrhUsername: String by project
+        val ossrhPassword: String by project
 
         maven {
             val releaseRepo =
@@ -49,12 +51,12 @@ fun Project.setupPublishingTasks() {
             url = if (!isSnapshotVersion()) releaseRepo else snapshotRepo
             credentials {
                 username = if (!isSnapshotVersion()) {
-                    project.properties["ossrhUsername"] as? String
+                    ossrhUsername
                 } else {
                     connectSnapshotsRepoUser
                 }
                 password = if (!isSnapshotVersion()) {
-                    project.properties["ossrhPassword"] as? String
+                    ossrhPassword
                 } else {
                     connectSnapshotsRepoPassword
                 }
@@ -124,5 +126,15 @@ fun Project.setupPublishingTasks() {
     }
 
     val signing = (project.extensions["signing"] as SigningExtension)
+    val signingSecretKey = findProperty("signing.secretKey") as? String
+    if (signingSecretKey != null) {
+        val signingKeyId: String by project
+        val signingPassword: String by project
+        signing.useInMemoryPgpKeys(
+            signingKeyId,
+            signingSecretKey,
+            signingPassword
+        )
+    }
     signing.sign(publishing.publications.getByName("mavenJava"))
 }


### PR DESCRIPTION
## Summary

- Upgrade Jackson `2.21.4` → `2.22.1` (security fix).
- Read Maven Central and GPG signing credentials from Jenkins instead of `~/.gradle/gradle.properties`.
- Sign in CI using a base64-encoded ASCII-armored GPG key (`useInMemoryPgpKeys`); local dev can still use `signing.secretKeyRingFile`.
- Add `verifyOssrhCredentials` to fail snapshot/release builds early on bad Maven Central auth (before GitHub release).