### PR TITLE
[CONNECTOR-1647] Limit Snyk and Dependabot scanning to root Gradle project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: maven
-    directory: /examples/jms
-    schedule:
-      interval: daily
-
-  - package-ecosystem: maven
-    directory: /examples/kafka
-    schedule:
-      interval: daily
-
-  - package-ecosystem: maven
-    directory: /examples/pulsar
+  - package-ecosystem: gradle
+    directory: /
     schedule:
       interval: daily

--- a/.snyk
+++ b/.snyk
@@ -4,4 +4,5 @@ ignore:
         reason: Library Exception allows non-free use of gnu-crypto
         expires: 2026-12-31T23:59:59.614Z
 exclude:
-  - ./examples
+  global:
+    - examples/**


### PR DESCRIPTION
## Summary
- Update `.snyk` to exclude `examples/**` using the supported `exclude.global` policy format
- Switch Dependabot from example Maven projects (`examples/jms`, `examples/kafka`, `examples/pulsar`) to the root Gradle project only

## Motivation
Example projects were generating unnecessary Snyk and Dependabot alerts/PRs. The main inbound SDK Gradle build should remain monitored, but the sample Maven examples should not.

## Test plan
- [ ] Verify `.github/dependabot.yml` monitors only `package-ecosystem: gradle` at `/`
- [ ] Verify `.snyk` excludes `examples/**`
- [x] Confirm example Maven projects still build unchanged in CI (`mvn -f examples/*`)
- [ ] After merge, confirm Dependabot opens PRs only for root Gradle dependencies
- [ ] After merge, retest/remove any existing Snyk monitors for example `pom.xml` projects if needed


Made with [Cursor](https://cursor.com)